### PR TITLE
Update for BHS 2023

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - nilearn
   - nibabel
   - pandas
+  - matplotlib

--- a/nilearn_demo.ipynb
+++ b/nilearn_demo.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# Read the data documentation\n",
-    "print(data['description'].decode('utf-8'))"
+    "print(data['description'])"
    ]
   },
   {


### PR DESCRIPTION
Just a few minor changes to prevent errors.

1. Added matplotlib to dependencies (otherwise, importing plotting from nilearn throws ModuleNotFoundError).
2. Dropped decode (otherwise, throws AttributeError since it's already a string).